### PR TITLE
Fix compilation with kernel >=4.3.x

### DIFF
--- a/src/dm-writeboost-daemon.c
+++ b/src/dm-writeboost-daemon.c
@@ -66,9 +66,9 @@ static void process_deferred_barriers(struct wb_device *wb, struct flush_job *jo
 		struct bio *bio;
 		while ((bio = bio_list_pop(&job->barrier_ios))) {
 			if (is_live(wb))
-				bio_endio(bio, 0);
+				bio_endio_compat(bio, 0)
 			else
-				bio_endio(bio, -EIO);
+				bio_endio_compat(bio, -EIO)
 		}
 	}
 }

--- a/src/dm-writeboost-target.c
+++ b/src/dm-writeboost-target.c
@@ -796,9 +796,9 @@ static int do_process_write(struct wb_device *wb, struct metablock *write_pos, s
 	}
 
 	if (is_live(wb))
-		bio_endio(bio, 0);
+		bio_endio_compat(bio, 0)
 	else
-		bio_endio(bio, -EIO);
+		bio_endio_compat(bio, -EIO)
 
 	return DM_MAPIO_SUBMITTED;
 }

--- a/src/dm-writeboost.h
+++ b/src/dm-writeboost.h
@@ -540,4 +540,15 @@ sector_t dm_devsize(struct dm_dev *);
 
 /*----------------------------------------------------------------------------*/
 
+
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0))
+	#define bio_endio_compat(bio,error) { \
+		bio->bi_error = error; \
+		bio_endio(bio); \
+		}
+#else
+	#define bio_endio_compat(bio,error) \
+		bio_endio(bio, error);
+#endif
+
 #endif


### PR DESCRIPTION
Fixes error with messages like:
> src/dm-writeboost-daemon.c:69:5: error: too many arguments to function ‘bio_endio’
     bio_endio(bio, 0);
     ^
