### PR TITLE
fixed issue: can not compile with linux-4.13

### DIFF
--- a/src/dm-writeboost-target.c
+++ b/src/dm-writeboost-target.c
@@ -112,7 +112,10 @@ sector_t dm_devsize(struct dm_dev *dev)
 
 void bio_endio_compat(struct bio *bio, int error)
 {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+	bio->bi_status = error;
+	bio_endio(bio);
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,3,0)
 	bio->bi_error = error;
 	bio_endio(bio);
 #else
@@ -1441,7 +1444,11 @@ static int writeboost_map(struct dm_target *ti, struct bio *bio)
 	return process_bio(wb, bio);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
+static int writeboost_end_io(struct dm_target *ti, struct bio *bio, blk_status_t *error)
+#else
 static int writeboost_end_io(struct dm_target *ti, struct bio *bio, int error)
+#endif
 {
 	struct wb_device *wb = ti->private;
 	struct per_bio_data *pbd = per_bio_data(wb, bio);


### PR DESCRIPTION
Linux-4.13でコンパイルできなくなったので、パッチに問題が無ければマージををお願いします。

エラー内容はこのような物でした
```
  CC [M]  /home/meke/build/trunk/pkgs/kernel/BUILD/kernel-4.13/dm-writeboost-2.2.7/src/dm-writeboost-target.o
/home/meke/build/trunk/pkgs/kernel/BUILD/kernel-4.13/dm-writeboost-2.2.7/src/dm-writeboost-target.c: In function 'bio_endio_compat':
/home/meke/build/trunk/pkgs/kernel/BUILD/kernel-4.13/dm-writeboost-2.2.7/src/dm-writeboost-target.c:116:7: error: 'struct bio' has no member named 'bi_error'; did you mean 'bi_iter'?
  bio->bi_error = error;
       ^~~~~~~~
       bi_iter
/home/meke/build/trunk/pkgs/kernel/BUILD/kernel-4.13/dm-writeboost-2.2.7/src/dm-writeboost-target.c: At top level:
/home/meke/build/trunk/pkgs/kernel/BUILD/kernel-4.13/dm-writeboost-2.2.7/src/dm-writeboost-target.c:1946:12: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
  .end_io = writeboost_end_io,
            ^~~~~~~~~~~~~~~~~
/home/meke/build/trunk/pkgs/kernel/BUILD/kernel-4.13/dm-writeboost-2.2.7/src/dm-writeboost-target.c:1946:12: note: (near initialization for 'writeboost_target.end_io')
cc1: some warnings being treated as errors
```
