### PR TITLE
change ACCESS_ONCE() to read_once()

### DIFF
--- a/src/dm-writeboost-daemon.c
+++ b/src/dm-writeboost-daemon.c
@@ -395,7 +395,7 @@ static u32 calc_nr_writeback(struct wb_device *wb)
 		atomic64_read(&wb->last_flushed_segment_id)
 		- atomic64_read(&wb->last_writeback_segment_id);
 
-	u32 nr_max_batch = ACCESS_ONCE(wb->nr_max_batched_writeback);
+	u32 nr_max_batch = read_once(wb->nr_max_batched_writeback);
 	if (wb->nr_writeback_segs != nr_max_batch)
 		try_alloc_writeback_ios(wb, nr_max_batch, GFP_NOIO | __GFP_NOWARN);
 
@@ -404,9 +404,9 @@ static u32 calc_nr_writeback(struct wb_device *wb)
 
 static bool should_writeback(struct wb_device *wb)
 {
-	return ACCESS_ONCE(wb->allow_writeback) ||
-	       ACCESS_ONCE(wb->urge_writeback)  ||
-	       ACCESS_ONCE(wb->force_drop);
+	return read_once(wb->allow_writeback) ||
+	       read_once(wb->urge_writeback)  ||
+	       read_once(wb->force_drop);
 }
 
 static void do_writeback_proc(struct wb_device *wb)
@@ -487,7 +487,7 @@ int writeback_modulator_proc(void *data)
 
 		util = div_u64(100 * (new - old), 1000);
 
-		if (util < ACCESS_ONCE(wb->writeback_threshold))
+		if (util < read_once(wb->writeback_threshold))
 			wb->allow_writeback = true;
 		else
 			wb->allow_writeback = false;
@@ -545,7 +545,7 @@ int sb_record_updater_proc(void *data)
 
 	while (!kthread_should_stop()) {
 		/* sec -> ms */
-		intvl = ACCESS_ONCE(wb->update_sb_record_interval) * 1000;
+		intvl = read_once(wb->update_sb_record_interval) * 1000;
 
 		if (!intvl) {
 			schedule_timeout_interruptible(msecs_to_jiffies(1000));
@@ -567,7 +567,7 @@ int data_synchronizer_proc(void *data)
 
 	while (!kthread_should_stop()) {
 		/* sec -> ms */
-		intvl = ACCESS_ONCE(wb->sync_data_interval) * 1000;
+		intvl = read_once(wb->sync_data_interval) * 1000;
 
 		if (!intvl) {
 			schedule_timeout_interruptible(msecs_to_jiffies(1000));

--- a/src/dm-writeboost-target.c
+++ b/src/dm-writeboost-target.c
@@ -782,7 +782,7 @@ static bool reserve_read_cache_cell(struct wb_device *wb, struct bio *bio)
 
 	ASSERT(cells->threshold > 0);
 
-	if (!ACCESS_ONCE(wb->read_cache_threshold))
+	if (!read_once(wb->read_cache_threshold))
 		return false;
 
 	if (!cells->cursor)
@@ -973,7 +973,7 @@ static void reinit_read_cache_cells(struct wb_device *wb)
 		struct read_cache_cell *cell = cells->array + i;
 		cell->cancelled = false;
 	}
-	cur_threshold = ACCESS_ONCE(wb->read_cache_threshold);
+	cur_threshold = read_once(wb->read_cache_threshold);
 	if (cur_threshold && (cur_threshold != cells->threshold)) {
 		cells->threshold = cur_threshold;
 		cells->over_threshold = false;

--- a/src/dm-writeboost.h
+++ b/src/dm-writeboost.h
@@ -520,4 +520,12 @@ sector_t dm_devsize(struct dm_dev *);
 
 /*----------------------------------------------------------------------------*/
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,15,0)
+#define read_once(x) READ_ONCE(x)
+#else
+#define read_once(x) ACCESS_ONCE(x)
+#endif
+
+/*----------------------------------------------------------------------------*/
+
 #endif


### PR DESCRIPTION
I've never contributed to a Github project before, so I am sorry if I am missing something.

I updated the version to 2.2.9, and changed all use of ACCESS_ONCE() to the macro read_or_access_once(). I tested the changes by running Postmark on the mapped device in Linux v4.15.3 and v4.10.0.