### PR TITLE
Fix Linux 5.8 build: gc error parameter from blkdev_issue_flush()

### DIFF
--- a/src/dm-writeboost-daemon.c
+++ b/src/dm-writeboost-daemon.c
@@ -62,7 +62,7 @@ static void process_deferred_barriers(struct wb_device *wb, struct rambuffer *ra
 		struct bio *bio;
 
 		/* Make all the preceding data persistent. */
-		int err = blkdev_issue_flush(wb->cache_dev->bdev, GFP_NOIO, NULL);
+		int err = dm_blkdev_issue_flush(wb->cache_dev->bdev, GFP_NOIO);
 
 		/* Ack the chained barrier requests. */
 		while ((bio = bio_list_pop(&rambuf->barrier_ios)))
@@ -378,7 +378,7 @@ static bool do_writeback_segs(struct wb_device *wb)
 	if (!try_writeback_segs(wb))
 		return false;
 
-	blkdev_issue_flush(wb->backing_dev->bdev, GFP_NOIO, NULL);
+	dm_blkdev_issue_flush(wb->backing_dev->bdev, GFP_NOIO);
 	return true;
 }
 
@@ -578,7 +578,7 @@ int data_synchronizer_proc(void *data)
 		}
 
 		flush_current_buffer(wb);
-		blkdev_issue_flush(wb->cache_dev->bdev, GFP_NOIO, NULL);
+		dm_blkdev_issue_flush(wb->cache_dev->bdev, GFP_NOIO);
 		schedule_timeout_interruptible(msecs_to_jiffies(intvl));
 	}
 	return 0;

--- a/src/dm-writeboost-metadata.c
+++ b/src/dm-writeboost-metadata.c
@@ -507,7 +507,7 @@ static int format_all_segment_headers(struct wb_device *wb)
 		goto bad;
 	}
 
-	err = blkdev_issue_flush(dev->bdev, GFP_KERNEL, NULL);
+	err = dm_blkdev_issue_flush(dev->bdev, GFP_KERNEL);
 
 bad:
 	mempool_free(buf, wb->buf_8_pool);

--- a/src/dm-writeboost-target.c
+++ b/src/dm-writeboost-target.c
@@ -1837,7 +1837,7 @@ static void writeboost_postsuspend(struct dm_target *ti)
 {
 	struct wb_device *wb = ti->private;
 	flush_current_buffer(wb);
-	blkdev_issue_flush(wb->cache_dev->bdev, GFP_NOIO, NULL);
+	dm_blkdev_issue_flush(wb->cache_dev->bdev, GFP_NOIO);
 }
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,17,0)

--- a/src/dm-writeboost.h
+++ b/src/dm-writeboost.h
@@ -528,4 +528,10 @@ sector_t dm_devsize(struct dm_dev *);
 
 /*----------------------------------------------------------------------------*/
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+#define dm_blkdev_issue_flush(x, y) blkdev_issue_flush(x, y)
+#else
+#define dm_blkdev_issue_flush(x, y) blkdev_issue_flush(x, y, NULL)
+#endif
+
 #endif


### PR DESCRIPTION
commit 9398554fb3 "block: remove the error_sector argument to
blkdev_issue_flush" removed the unused error parameter from blkdev_issue_flush()
- fix the code accordingly

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>