### PR TITLE
uninitialized_var macro was removed in linux-5.9

### DIFF
--- a/src/dm-writeboost.h
+++ b/src/dm-writeboost.h
@@ -534,4 +534,10 @@ sector_t dm_devsize(struct dm_dev *);
 #define dm_blkdev_issue_flush(x, y) blkdev_issue_flush(x, y, NULL)
 #endif
 
+/*----------------------------------------------------------------------------*/
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,9,0)
+#define uninitialized_var(x) x = x
+#endif
+
 #endif


### PR DESCRIPTION
uninitialized_var macro was removed in linux-5.9.

tested on linux-5.9, but I haven't tested it in other environments

```
  CC [M]  /home/meke/trunk/pkgs/kernel/BUILD/kernel-5.9/dm-writeboost-2.2.12/src/dm-writeboost-metadata.o
/home/meke/trunk/pkgs/kernel/BUILD/kernel-5.9/dm-writeboost-2.2.12/src/dm-writeboost-metadata.c: In function 'infer_last_writeback_id':
/home/meke/trunk/pkgs/kernel/BUILD/kernel-5.9/dm-writeboost-2.2.12/src/dm-writeboost-metadata.c:984:9: warning: parameter names (without types) in function declaration
  984 |  struct superblock_record_device uninitialized_var(record);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~
/home/meke/trunk/pkgs/kernel/BUILD/kernel-5.9/dm-writeboost-2.2.12/src/dm-writeboost-metadata.c:985:32: error: 'record' undeclared (first use in this function); did you mean 'record_id'?
  985 |  err = read_superblock_record(&record, wb);
      |                                ^~~~~~
      |                                record_id
/home/meke/trunk/pkgs/kernel/BUILD/kernel-5.9/dm-writeboost-2.2.12/src/dm-writeboost-metadata.c:985:32: note: each undeclared identifier is reported only once for each function it appears in
make[2]: *** [scripts/Makefile.build:283: /home/meke/trunk/pkgs/kernel/BUILD/kernel-5.9/dm-writeboost-2.2.12/src/dm-writeboost-metadata.o] Error 1
```
