### PR TITLE
Fix Linux 5.9 build: remove uninitialized_var() usage

### DIFF
--- a/src/dm-writeboost-metadata.c
+++ b/src/dm-writeboost-metadata.c
@@ -981,7 +981,7 @@ static int infer_last_writeback_id(struct wb_device *wb)
 	u64 inferred_last_writeback_id;
 	u64 record_id;
 
-	struct superblock_record_device uninitialized_var(record);
+	struct superblock_record_device record;
 	err = read_superblock_record(&record, wb);
 	if (err)
 		return err;


### PR DESCRIPTION
It's dangerous, can hide real bugs and suppress compiler warnings (see also
63a0895d960a "compiler: Remove uninitialized_var() macroi") and it has been
retired upstream in 5.9.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>