### PR TITLE
blkdev_issue_flush: discard unused memory allocation flags

### DIFF
--- a/src/dm-writeboost.h
+++ b/src/dm-writeboost.h
@@ -528,7 +528,9 @@ sector_t dm_devsize(struct dm_dev *);
 
 /*----------------------------------------------------------------------------*/
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,12,0)
+#define dm_blkdev_issue_flush(x, y) blkdev_issue_flush(x)
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(5,8,0)
 #define dm_blkdev_issue_flush(x, y) blkdev_issue_flush(x, y)
 #else
 #define dm_blkdev_issue_flush(x, y) blkdev_issue_flush(x, y, NULL)


### PR DESCRIPTION
Since:

commit c6bf3f0e25f4c0f0ecce6cf8d1c589bd9d74d3cf
Author: Christoph Hellwig <hch@lst.de>
Date:   Tue Jan 26 15:52:35 2021 +0100

    block: use an on-stack bio in blkdev_issue_flush

 is no point in allocating memory for a synchronous flush.

blkdev_issue_flush() doesn't accept memory allocation flags as a
parameter anymore, so discard them.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>