### PR TITLE
dm-writeboost-target.c: Fix build error in 6.10

### DIFF
--- a/src/dm-writeboost-target.c
+++ b/src/dm-writeboost-target.c
@@ -116,7 +116,11 @@ int wb_io_internal(struct wb_device *wb, struct dm_io_request *io_req,
 
 sector_t dm_devsize(struct dm_dev *dev)
 {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
 	return i_size_read(dev->bdev->bd_inode) >> 9;
+#else
+	return bdev_nr_sectors(dev->bdev);
+#endif
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/dm-writeboost-target.c
+++ b/src/dm-writeboost-target.c
@@ -116,7 +116,7 @@ int wb_io_internal(struct wb_device *wb, struct dm_io_request *io_req,
 
 sector_t dm_devsize(struct dm_dev *dev)
 {
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 10, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
 	return i_size_read(dev->bdev->bd_inode) >> 9;
 #else
 	return bdev_nr_sectors(dev->bdev);


### PR DESCRIPTION
`bdev->bd_inode` was removed in 6.10; replace it with `bdev_nr_sectors`

See kernel commit: https://github.com/torvalds/linux/commit/203c1ce0bb063d1620698e39637b64f2d09c1368

Closes #256 