### PR TITLE
Use writer lock instead of mutex

### DIFF
--- a/src/dm-writeboost-daemon.c
+++ b/src/dm-writeboost-daemon.c
@@ -30,9 +30,9 @@
 
 void queue_barrier_io(struct wb_device *wb, struct bio *bio)
 {
-	mutex_lock(&wb->io_lock);
+	down_write(&wb->io_lock);
 	bio_list_add(&wb->barrier_ios, bio);
-	mutex_unlock(&wb->io_lock);
+	up_write(&wb->io_lock);
 
 	/*
 	 * queue_work does nothing if the work is already in the queue.

--- a/src/dm-writeboost.h
+++ b/src/dm-writeboost.h
@@ -27,6 +27,7 @@
 #include <linux/list.h>
 #include <linux/slab.h>
 #include <linux/vmalloc.h>
+#include <linux/rwsem.h>
 #include <linux/mutex.h>
 #include <linux/kthread.h>
 #include <linux/sched.h>
@@ -261,7 +262,7 @@ struct wb_device {
 	const char **ctr_args;
 
 	bool do_format; /* True if it was the first creation */
-	struct mutex io_lock; /* Mutex is light-weighed */
+	struct rw_semaphore io_lock;
 
 	/*
 	 * Wq to wait for nr_inflight_ios to be zero.


### PR DESCRIPTION
The reason writeboost uses mutex is to optimize for writer (mutex_lock/unlock is efficient than down/up_write), but in the sacrifice of reader concurrency. This PR uses rw_semaphore instead for more efficient exclusive control.