### PR TITLE
Use atomic_t instead of bool as cell->cancelled

### DIFF
--- a/src/dm-writeboost.h
+++ b/src/dm-writeboost.h
@@ -207,7 +207,7 @@ struct writeback_segment {
 struct read_cache_cell {
 	sector_t sector;
 	void *data; /* 4KB data read */
-	bool cancelled; /* Don't include this */
+	atomic_t cancelled; /* Don't include this */
 	struct rb_node rb_node;
 };
 


### PR DESCRIPTION
When cache cells are fulfilled, injection work is queued. Before cells are injected, they may be cancelled by the foreground path. Therefore, atomic type should be used.